### PR TITLE
tier1 always be None in GET tier config request for level 2

### DIFF
--- a/connect/models/schemas.py
+++ b/connect/models/schemas.py
@@ -501,7 +501,7 @@ class TierAccountSchema(BaseSchema):
 
 class TierAccountsSchema(Schema):
     customer = fields.Nested(TierAccountSchema)
-    tier1 = fields.Nested(TierAccountSchema)
+    tier1 = fields.Nested(TierAccountSchema, allow_none=True)
     tier2 = fields.Nested(TierAccountSchema, allow_none=True)
 
     @post_load


### PR DESCRIPTION
Without having null allowable SDK will throw the following error  
TypeError: Invalid structure for initialization of `TierConfigRequest`. 
Error: {0: {'tiers': {'tier1': ['Field may not be null.']}}, 1: {'tiers': {'tier1': ['Field may not be null.']}}}.

Because in t2 config request t1 account always be none as per api result from connect platform

![image](https://user-images.githubusercontent.com/38108510/66552663-6169e700-eb67-11e9-8fbf-def15d3e2611.png)
